### PR TITLE
Fixes infinite loop

### DIFF
--- a/gatsby/createCategories.js
+++ b/gatsby/createCategories.js
@@ -1,9 +1,9 @@
 const path = require(`path`)
 module.exports = async ({ actions, graphql }) => {
   const GET_CATEGORIES = `
-  query GET_CATEGORIES($first: Int) {
-    wpgraphql { 
-      categories(first: $first) {
+  query GET_CATEGORIES($first: Int, $after: String) {
+    wpgraphql {
+      tags(first: $first, after: $after) {
         pageInfo {
           hasNextPage
           endCursor

--- a/gatsby/createCategories.js
+++ b/gatsby/createCategories.js
@@ -3,7 +3,7 @@ module.exports = async ({ actions, graphql }) => {
   const GET_CATEGORIES = `
   query GET_CATEGORIES($first: Int, $after: String) {
     wpgraphql {
-      tags(first: $first, after: $after) {
+      categories(first: $first, after: $after) {
         pageInfo {
           hasNextPage
           endCursor

--- a/gatsby/createTags.js
+++ b/gatsby/createTags.js
@@ -1,9 +1,9 @@
 const path = require(`path`)
 module.exports = async ({ actions, graphql }) => {
   const GET_TAGS = `
-  query GET_TAGS($first: Int) {
-    wpgraphql { 
-      tags(first: $first) {
+  query GET_TAGS($first: Int, $after: String) {
+    wpgraphql {
+      tags(first: $first, after: $after) {
         pageInfo {
           hasNextPage
           endCursor


### PR DESCRIPTION
`fetchTags` and `fetchCategories` is called recursively if there are more than 100 posts. Cursor is passed but never used in the query which results in an infinite loop if you have more than a 100 categories or tags :). 